### PR TITLE
Framedurationandlloopcount

### DIFF
--- a/YLGIFImage/YLGIFImage.h
+++ b/YLGIFImage/YLGIFImage.h
@@ -32,5 +32,6 @@
 @property (nonatomic, readonly) NSUInteger loopCount;
 
 - (UIImage*)getFrameWithIndex:(NSUInteger)idx;
+- (void)setLoopCountForAnimation:(NSUInteger)loopCount;
 
 @end

--- a/YLGIFImage/YLGIFImage.m
+++ b/YLGIFImage/YLGIFImage.m
@@ -183,7 +183,7 @@ static NSUInteger _prefetchedNum = 10;
     for (NSUInteger i = 0; i < numberOfFrames; ++i) {
         [self.images addObject:aNull];
         NSTimeInterval frameDuration = CGImageSourceGetGifFrameDelay(imageSource, i);
-        self.frameDurations[i] = frameDuration;
+        self.frameDurations[i] = frameDuration * 0.3;
         self.totalDuration += frameDuration;
     }
     //CFTimeInterval start = CFAbsoluteTimeGetCurrent();

--- a/YLGIFImage/YLGIFImage.m
+++ b/YLGIFImage/YLGIFImage.m
@@ -290,5 +290,8 @@ static NSUInteger _prefetchedNum = 10;
         CFRelease(_incrementalSource);
     }
 }
-
+- (void)setLoopCountForAnimation:(NSUInteger)loopCount
+{
+    _loopCount = loopCount;
+}
 @end


### PR DESCRIPTION
changes to increase framerate of gif to display with same or almost equal frame rate as displayed on web. And exposing a method to set the loop count explicitly
